### PR TITLE
Added support for aarch64 architecture

### DIFF
--- a/mk/module/platform.sh
+++ b/mk/module/platform.sh
@@ -629,6 +629,9 @@ option()
                 ppc)
                     _default_MK_BUILD_ARCH="powerpc"
                     ;;
+                aarch64)
+                    _default_MK_BUILD_ARCH="aarch64"
+                    ;;
                 *)
                     mk_fail "unknown architecture: `uname -m`"
                     ;;


### PR DESCRIPTION
Provided multi architecture support by adding a check for aarch64  in ```platform.sh``` file.
